### PR TITLE
Include req.session.user_name

### DIFF
--- a/controllers/api/user-routes.js
+++ b/controllers/api/user-routes.js
@@ -53,7 +53,8 @@ router.post('/signup', async (req, res) => {
     req.session.save(() => {
       req.session.user_id = userData.id;
       req.session.logged_in = true;
-
+      req.session.user_name = userData.username;
+      
       res.status(200).json({ success: true, data: userData});
     });
   } catch (err) {


### PR DESCRIPTION
Somehow  `req.session.user_name = userData.username` was removed from the /signup route, we need it for the discover page when adding a new comment by editing the DOM. Otherwise the username of the new comment shows up as @false until you reload the page and open the comments up again.